### PR TITLE
updated playbooks for postgresql upgrade

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,13 +1,13 @@
 ---
 - name: Initiate database
-  command: /usr/pgsql-10/bin/postgresql10-setup initdb
+  command: /usr/pgsql-11/bin/postgresql11-setup initdb
   args:
-    creates: /var/lib/pgsql/10/data/postgresql.conf
+    creates: /var/lib/pgsql/11/data/postgresql.conf
 
 - name: Set up postgresl connection permissions
   copy:
     src: pg_hba.conf
-    dest: /var/lib/pgsql/10/data/pg_hba.conf
+    dest: /var/lib/pgsql/11/data/pg_hba.conf
     owner: postgres
     group: postgres
     mode: 0700
@@ -16,7 +16,7 @@
 
 - name: Start PostgreSQL and enable at boot
   service:
-    name: postgresql-10
+    name: postgresql-11
     enabled: yes
     state: started
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,13 +1,13 @@
 ---
 - name: Initiate database
-  command: /usr/pgsql-9.4/bin/postgresql94-setup initdb
+  command: /usr/pgsql-10/bin/postgresql10-setup initdb
   args:
-    creates: /var/lib/pgsql/9.4/data/postgresql.conf
+    creates: /var/lib/pgsql/10/data/postgresql.conf
 
 - name: Set up postgresl connection permissions
   copy:
     src: pg_hba.conf
-    dest: /var/lib/pgsql/9.4/data/pg_hba.conf
+    dest: /var/lib/pgsql/10/data/pg_hba.conf
     owner: postgres
     group: postgres
     mode: 0700
@@ -16,7 +16,7 @@
 
 - name: Start PostgreSQL and enable at boot
   service:
-    name: postgresql-9.4
+    name: postgresql-10
     enabled: yes
     state: started
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,18 +1,12 @@
 ---
 
- #- name: Disable default postgres packages
- # copy:
- #   src: exclude-default-postgres.repo
- #   dest: /etc/yum.repos.d/exclude-default-postgres.repo
- #   owner: root
- #   group: root
- #   mode: 0644
-
-- name: Disable default postgres packages
-  yum:
-    name: "postgresql" 
-    state: absent
-
+ - name: Disable default postgres packages
+  copy:
+    src: exclude-default-postgres.repo
+    dest: /etc/yum.repos.d/exclude-default-postgres.repo
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Install PGDG repository config RPM
   yum:
@@ -24,5 +18,5 @@
     name: "{{ item }}"
     state: installed
   with_items:
-      - postgresql94-server
-      - postgresql94-contrib
+      - postgresql10-server
+      - postgresql10-contrib

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Disable default postgres packages
+- name: Verify that we are not using default PostgreSQL packages 
   yum:
     name: "postgresql"
     state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,7 +7,7 @@
 
 - name: Install PGDG repository config RPM
   yum:
-    name: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+    name: "https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/pgdg-centos11-11-2.noarch.rpm"
     state: installed
 
 - name: Install Postgresql server package
@@ -15,5 +15,5 @@
     name: "{{ item }}"
     state: installed
   with_items:
-      - postgresql10-server
-      - postgresql10-contrib
+      - postgresql11-server
+      - postgresql11-contrib

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,12 +1,9 @@
 ---
 
- - name: Disable default postgres packages
-  copy:
-    src: exclude-default-postgres.repo
-    dest: /etc/yum.repos.d/exclude-default-postgres.repo
-    owner: root
-    group: root
-    mode: 0644
+- name: Disable default postgres packages
+  yum:
+    name: "postgresql"
+    state: absent
 
 - name: Install PGDG repository config RPM
   yum:


### PR DESCRIPTION
Updated postgresql role for upgrade to psql 10

replaced "9.4" and "94" with "10" in install.yml and configure.yml

Motivation and Context
----------------------
These changes allow the OULibraries.postgresql-server role to install postgres 10

How Has This Been Tested?
-------------------------
Tested when using ansible to build the dspace 6.2 environment to test the ShareOK upgrade.
