### PR TITLE
Ansible 2.9 Upgrade

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Logan Cox
-  description: 
+  description:
   company: University of Oklahoma Libraries
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -17,7 +17,7 @@ galaxy_info:
   min_ansible_version: 1.2
   #
   # Below are all platforms currently available. Just uncomment
-  # the ones that apply to your role. If you don't see your 
+  # the ones that apply to your role. If you don't see your
   # platform on this list, let us know and we'll get it added!
   #
   #platforms:
@@ -144,4 +144,4 @@ dependencies: []
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  
+

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Verify that we are not using default PostgreSQL packages 
+- name: Verify that we are not using default PostgreSQL packages
   yum:
     name: "postgresql"
     state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,7 +7,7 @@
 
 - name: Install PGDG repository config RPM
   yum:
-    name: "https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/pgdg-centos11-11-2.noarch.rpm"
+    name: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     state: installed
 
 - name: Install Postgresql server package

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 - include: install.yml
-  sudo: yes
+  become: yes
 - include: configure.yml
-  sudo: yes
+  become: yes


### PR DESCRIPTION
Update/Upgrade syntaxes for Ansible 2.9 upgrade

The sudo flag has been deprecated for a while, it is now a breaking change so it needs to be updated to use the `become` flag instead. Also removed trailing whitespaces for cleanliness. 

Motivation and Context
----------------------
Deprecated methods/commands are now considered breaking changes. 

How Has This Been Tested?
-------------------------
Utilized in DSpace role against a local VM. 
